### PR TITLE
relocate badge urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Build Status](https://travis-ci.org/rbast/presence-analyzer-rbast.svg?branch=bug_5864)](https://travis-ci.org/rbast/presence-analyzer-rbast) [![Coverage Status](https://coveralls.io/repos/rbast/presence-analyzer-rbast/badge.svg?branch=bug_5864)](https://coveralls.io/r/rbast/presence-analyzer-rbast?branch=bug_5864)
+[![Build Status](https://travis-ci.org/stxnext-kindergarten/presence-analyzer-rbast.svg?branch=master)](https://travis-ci.org/stxnext-kindergarten/presence-analyzer-rbast) [![Coverage Status](https://coveralls.io/repos/stxnext-kindergarten/presence-analyzer-rbast/badge.svg?branch=master)](https://coveralls.io/r/stxnext-kindergarten/presence-analyzer-rbast?branch=master)
 
 
 Presence Analyzer


### PR DESCRIPTION
Changed URLs to stxnext-kindergarten repo. This makes Coveralls badge "unknown" for the moment.